### PR TITLE
Remaining locations which are supported by current implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,27 @@
 [![Build Status](https://travis-ci.org/srehwald/eat-api.svg?branch=master)](https://travis-ci.org/srehwald/eat-api)
 
 Simple static API for the canteens of the [Studentenwerk München](http://www.studentenwerk-muenchen.de) as well as some other locations. By now, the following locations are supported:
-- Mensa Garching (mensa-garching)
-- Mensa Arcisstraße (mensa-arcisstrasse)
-- StuBistro Großhadern (stubistro-grosshadern)
-- FMI Bistro Garching (fmi-bistro)
-- IPP Bistro Garching (ipp-bistro)
+
+ - Mensa Arcisstraße (mensa-arcisstr), Arcisstraße 17, München
+ - Mensa Garching (mensa-garching), Lichtenbergstraße 2, Garching
+ - Mensa Leopoldstraße (mensa-leopoldstr), Leopoldstraße 13a, München
+ - Mensa Lothstraße (mensa-lothstr), Lothstraße 13d, München
+ - Mensa Martinsried (mensa-martinsried), Großhaderner Straße 6, Planegg-Martinsried
+ - Mensa Pasing (mensa-pasing), Am Stadtpark 20, München
+ - Mensa Weihenstephan (mensa-weihenstephan), Maximus-von-Imhof-Forum 5, Freising
+ - StuBistro Arcisstraße (stubistro-arcisstr), Arcisstraße 12, München
+ - StuBistro Goethestraße (stubistro-goethestr), Goethestraße 70, München
+ - StuBistro Großhadern (stubistro-grosshadern), Butenandtstraße 13, Gebäude F, München
+ - StuBistro Rosenheim (stubistro-rosenheim), Hochschulstraße 1, Rosenheim
+ - StuBistro Schellingstraße (stubistro-schellingstr), Schellingstraße 3, München
+ - StuCafé Adalbertstraße (stucafe-adalbertstr), Adalbertstraße 5, München
+ - StuCafé Akademie Weihenstephan (stucafe-akademie-weihenstephan), Alte Akademie 1, Freising
+ - StuCafé Boltzmannstraße (stucafe-boltzmannstr), Boltzmannstraße 15, Garching
+ - StuCafé in der Mensa Garching (stucafe-garching), Lichtenbergstraße 2, Garching
+ - StuCafé Karlstraße (stucafe-karlstr), Karlstraße 6, München
+ - StuCafé Pasing (stucafe-pasing), Am Stadtpark 20, München
+ - FMI Bistro Garching (fmi-bistro), Boltzmannstraße 3, 85748 Garching
+ - IPP Bistro Garching (ipp-bistro), Boltzmannstraße 2, 85748 Garching
 
 ## Usage
 

--- a/scripts/parse.sh
+++ b/scripts/parse.sh
@@ -1,8 +1,16 @@
-#!/bin/sh
-mkdir dist
-python src/main.py mensa-garching -j ./dist/mensa-garching
-python src/main.py mensa-arcisstrasse -j ./dist/mensa-arcisstrasse
-python src/main.py stubistro-grosshadern -j ./dist/stubistro-grosshadern
-python src/main.py fmi-bistro -j ./dist/fmi-bistro
-python src/main.py ipp-bistro -j ./dist/ipp-bistro
+#!/bin/bash
+
+# --parents prevents error exit if folder already exists
+mkdir --parents dist
+
+loc_list=( "mensa-arcisstr" "mensa-arcisstrasse" "mensa-garching" "mensa-leopoldstr" "mensa-lothstr" \
+"mensa-martinsried" "mensa-pasing" "mensa-weihenstephan" "stubistro-arcisstr" "stubistro-goethestr" \
+"stubistro-großhadern" "stubistro-grosshadern" "stubistro-rosenheim" "stubistro-schellingstr" "stucafe-adalbertstr" \
+"stucafe-akademie-weihenstephan" "stucafe-boltzmannstr" "stucafe-garching" "stucafe-karlstr" "stucafe-pasing" \
+"ipp-bistro" "fmi-bistro" )
+
+for loc in "${loc_list[@]}"; do
+    python src/main.py "$loc" --jsonify "./dist/$loc"
+done
+
 tree dist/

--- a/src/cli.py
+++ b/src/cli.py
@@ -2,11 +2,13 @@
 
 import argparse
 
+import menu_parser
+
 
 def parse_cli_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument('location', choices=['mensa-garching', 'mensa-arcisstrasse', 'stubistro-grosshadern',
-                                             'fmi-bistro', 'ipp-bistro'],
+    parser.add_argument('location', choices=(
+            ['fmi-bistro', 'ipp-bistro'] + list(menu_parser.StudentenwerkMenuParser.location_id_mapping.keys())),
                         help='the location you want to eat at')
     parser.add_argument('-d', '--date', help='date (DD.MM.YYYY) of the day of which you want to get the menu')
     parser.add_argument('-j', '--jsonify',

--- a/src/main.py
+++ b/src/main.py
@@ -13,7 +13,7 @@ def get_menu_parsing_strategy(location):
     parser = None
 
     # set parsing strategy based on location
-    if location in ["mensa-garching", "mensa-arcisstrasse", "stubistro-grosshadern"]:
+    if isinstance(location, int) or location in menu_parser.StudentenwerkMenuParser.location_id_mapping.keys():
         parser = menu_parser.StudentenwerkMenuParser()
     elif location == "fmi-bistro":
         parser = menu_parser.FMIBistroMenuParser()

--- a/src/menu_parser.py
+++ b/src/menu_parser.py
@@ -24,8 +24,10 @@ class StudentenwerkMenuParser(MenuParser):
         "Aktionsessen 5": 2.8, "Aktionsessen 6": 3.0, "Aktionsessen 7": 3.2, "Aktionsessen 8": 3.5, "Aktionsessen 9": 4,
         "Aktionsessen 10": 4.5, "Biogericht 1": 1.55, "Biogericht 2": 1.9, "Biogericht 3": 2.4, "Biogericht 4": 2.6,
         "Biogericht 5": 2.8, "Biogericht 6": 3.0, "Biogericht 7": 3.2, "Biogericht 8": 3.5, "Biogericht 9": 4,
-        "Biogericht 10": 4.5, "Self-Service": "Self-Service", "Self-Service Grüne Mensa": "Self-Service Grüne Mensa",
-        "Baustellenteller": "Baustellenteller (2.40€ - 3.45€)", "Fast Lane": "Fast Lane (3.50€ - 5.20€)"
+        "Biogericht 10": 4.5, "Self-Service": "0,68€ / 100g", "Self-Service Grüne Mensa": "0,33€ / 100g",
+        "Baustellenteller": "Baustellenteller (> 2.40€)", "Fast Lane": "Fast Lane (> 3.50€)",
+        "Länder-Mensa": "0.75€ / 100g", "Mensa Spezial Pasta": "0.60€ / 100g",
+        "Mensa Spezial": "0.85€ / 100g (one-course dishes have individual prices)",
     }
     links = {
         "mensa-garching": 'http://www.studentenwerk-muenchen.de/mensa/speiseplan/speiseplan_422_-de.html',

--- a/src/menu_parser.py
+++ b/src/menu_parser.py
@@ -26,7 +26,7 @@ class StudentenwerkMenuParser(MenuParser):
         "Aktionsessen 5": 2.8, "Aktionsessen 6": 3.0, "Aktionsessen 7": 3.2, "Aktionsessen 8": 3.5, "Aktionsessen 9": 4,
         "Aktionsessen 10": 4.5, "Biogericht 1": 1.55, "Biogericht 2": 1.9, "Biogericht 3": 2.4, "Biogericht 4": 2.6,
         "Biogericht 5": 2.8, "Biogericht 6": 3.0, "Biogericht 7": 3.2, "Biogericht 8": 3.5, "Biogericht 9": 4,
-        "Biogericht 10": 4.5, "Self-Service": "0,68€ / 100g", "Self-Service Grüne Mensa": "0,33€ / 100g",
+        "Biogericht 10": 4.5, "Self-Service": "0.68€ / 100g", "Self-Service Grüne Mensa": "0.33€ / 100g",
         "Baustellenteller": "Baustellenteller (> 2.40€)", "Fast Lane": "Fast Lane (> 3.50€)",
         "Länder-Mensa": "0.75€ / 100g", "Mensa Spezial Pasta": "0.60€ / 100g",
         "Mensa Spezial": "0.85€ / 100g (one-course dishes have individual prices)",

--- a/src/menu_parser.py
+++ b/src/menu_parser.py
@@ -91,8 +91,19 @@ class StudentenwerkMenuParser(MenuParser):
         # create dictionary out of dish name and dish type
         dishes_dict = {dish_name: dish_type for dish_name, dish_type in zip(dish_names, dish_types)}
         # create Dish objects with correct prices; if price is not available, -1 is used instead
-        dishes = [Dish(name, StudentenwerkMenuParser.prices.get(dishes_dict[name], "N/A")) for name in dishes_dict]
+
+        dishes = []
+        for name in dishes_dict:
+            if not dishes_dict[name]:
+                # some dishes are multi-row. That means that for the same type the dish is written in multiple rows.
+                # From the second row on the type is then just empty. In that case, we just use the price of the
+                # previous dish.
+                dishes.append(Dish(name, dishes[-1].price))
+            else:
+                dishes.append(Dish(name, StudentenwerkMenuParser.prices.get(dishes_dict[name], "N/A")))
+
         return dishes
+
 
 class FMIBistroMenuParser(MenuParser):
     url = "http://www.wilhelm-gastronomie.de/tum-garching"

--- a/src/menu_parser.py
+++ b/src/menu_parser.py
@@ -29,7 +29,7 @@ class StudentenwerkMenuParser(MenuParser):
         "Biogericht 10": 4.5, "Self-Service": "0.68€ / 100g", "Self-Service Grüne Mensa": "0.33€ / 100g",
         "Baustellenteller": "Baustellenteller (> 2.40€)", "Fast Lane": "Fast Lane (> 3.50€)",
         "Länder-Mensa": "0.75€ / 100g", "Mensa Spezial Pasta": "0.60€ / 100g",
-        "Mensa Spezial": "0.85€ / 100g (one-course dishes have individual prices)",
+        "Mensa Spezial": "individual",  # 0.85€ / 100g (one-course dishes have individual prices)
     }
 
     # Some of the locations do not use the general Studentenwerk system and do not have a location id.

--- a/src/test/test_menu_parser.py
+++ b/src/test/test_menu_parser.py
@@ -48,9 +48,9 @@ class StudentenwerkMenuParserTest(unittest.TestCase):
     dish1_4_arcisstrasse = Dish("Pasta Pomodori", 1.9)
     dish1_5_arcisstrasse = Dish("Gebackene Calamari-Ringe mit Zitronen-Knoblauch-Dip", 2.6)
     dish1_6_arcisstrasse = Dish("Seelachsfilet (MSC) im Sesammantel mit Zitronen-Knoblauch-Dip", 2.6)
-    dish1_7_arcisstrasse = Dish("Pasta Pomodori (2)", "Self-Service")
-    dish1_8_arcisstrasse = Dish("Kartoffelgulasch mit Paprika (2)", "Self-Service")
-    dish1_9_arcisstrasse = Dish("Pasta mit Sojabolognese", "Self-Service")
+    dish1_7_arcisstrasse = Dish("Pasta Pomodori (2)", "0.68€ / 100g")
+    dish1_8_arcisstrasse = Dish("Kartoffelgulasch mit Paprika (2)", "0.68€ / 100g")
+    dish1_9_arcisstrasse = Dish("Pasta mit Sojabolognese", "0.68€ / 100g")
     menu1_arcisstrasse = Menu(menu1_date, [dish1_1_arcisstrasse, dish1_2_arcisstrasse, dish1_3_arcisstrasse,
                                            dish1_4_arcisstrasse, dish1_5_arcisstrasse, dish1_6_arcisstrasse,
                                            dish1_7_arcisstrasse, dish1_8_arcisstrasse, dish1_9_arcisstrasse])


### PR DESCRIPTION
Luckily the Studentenwerk homepage for presenting the dishes is quite standardised and your implementation works with most of them. This PR adds the rest of the locations which works. The homepages of the remaining locations are quite different and probably  everyone needs an own parser.

I tested all new locations and the parsing looks all fine.

Some notes:

  + I specify the location only through its ID instead the full url since it is the only thing which differs
  + Likewise parse() accepts now also the location ID besides the strings
  + I referenced multiple times the list in the Studentenwerk class `menu_parser.StudentenwerkMenuParser.location_id_mapping.keys()`. That should be better than defining the same list multiple times.
  + "Baustellenteller (> 2.40€)", "Fast Lane": "Fast Lane (> 3.50€)" has changed to greater a price, because the homepage says „ab 2,40 €“ / „ab 3,50 €“. Note that the columns refer to „für Studierende | für Bedienstete | für Gäste“ and do not denote the possible price range
  + some prices were added and now also shows the price per 100g
  + the price `"0.85€ / 100g (one-course dishes have individual prices)"` end up to be quite long but I have no better idea (and this one is the only occurrence where we need this)
  + some dishes are 'Mensa Klassiker'. However the price is still missing because this type is not mentioned on the homepage
  + I ended up also changing to `"Self-Service": "0.68€ / 100g", "Self-Service Grüne Mensa": "0.33€ / 100g"` instead of self-service. There are concrete prices on the homepage for that but it is probably a bit of a taste, ignore that if you thing the older one is better
  + To workaround the problem that „straße“ has spacial character in it I used the very common way to just use the abbreviation „str”. That way you have the bonus that you do not have to write so much.