### PR TITLE
Fixed crash for multirow dishes

### DIFF
--- a/src/menu_parser.py
+++ b/src/menu_parser.py
@@ -135,7 +135,7 @@ class StudentenwerkMenuParser(MenuParser):
 
         dishes = []
         for name in dishes_dict:
-            if not dishes_dict[name]:
+            if not dishes_dict[name] and dishes:
                 # some dishes are multi-row. That means that for the same type the dish is written in multiple rows.
                 # From the second row on the type is then just empty. In that case, we just use the price of the
                 # previous dish.


### PR DESCRIPTION
The program tries to access the last index of the `dishes` array although it's empty.

### Which canteens produce this error:
stubistro-rosenheim
mensa-leopoldstr
mensa-arcisstrasse
mensa-arcisstr

### Which menu/dish produces this error (one example):
The dishes "Rahmchampignons" and "Semmelknödel" produce it for Tuesday 23.01.2018. ([link to the menu](http://www.studentenwerk-muenchen.de/mensa/speiseplan/speiseplan-kw_2018-04_411_-de.pdf)).


### Help/Test code:
Just replace line 137 to 146 with the following code snipped. It will output all dishes, that cause this problem.
```
        for name in dishes_dict:
            try:
                if not dishes_dict[name]:
                # some dishes are multi-row. That means that for the same type the dish is written in multiple rows.
                # From the second row on the type is then just empty. In that case, we just use the price of the
                # previous dish.
                    dishes.append(Dish(name, dishes[-1].price))
                else:
                    dishes.append(Dish(name, StudentenwerkMenuParser.prices.get(dishes_dict[name], "N/A")))
            except Exception as e:
                print(name +  ' ' + str(len(dishes)))

        return dishes
```
### Exception:
```
Traceback (most recent call last):
  File "main.py", line 94, in <module>
    main()
  File "main.py", line 58, in main
    menus = parser.parse(location)
  File "/home/fabian/Dokumente/eat-api/src/menu_parser.py", line 86, in parse
    return self.get_menus(tree)
  File "/home/fabian/Dokumente/eat-api/src/menu_parser.py", line 109, in get_menus
    dishes = self.__parse_dishes(menu_html)
  File "/home/fabian/Dokumente/eat-api/src/menu_parser.py", line 142, in __parse_dishes
    dishes.append(Dish(name, dishes[-1].price))
IndexError: list index out of range
```