### PR TITLE
wn/year regex for IPP pdf

### DIFF
--- a/src/menu_parser.py
+++ b/src/menu_parser.py
@@ -277,8 +277,10 @@ class IPPBistroMenuParser(MenuParser):
         for pdf_url in xpath_query:
             # Example PDF-name: KW-48_27.11-01.12.10.2017-3.pdf
             pdf_name = pdf_url.split("/")[-1]
-            year = int(pdf_name.replace(".pdf","").split(".")[-1].split("-")[0])
-            week_number = int(pdf_name.split("_")[0].replace("KW-","").lstrip("0"))
+            # more examples: https://regex101.com/r/hwdpFx/1
+            wn_year_match = re.search("KW[^a-zA-Z1-9]*([1-9]+\d*).*\d+\.\d+\.(\d+).*", pdf_name, re.IGNORECASE)
+            week_number = int(wn_year_match.group(1)) if wn_year_match else None
+            year = int(wn_year_match.group(2)) if wn_year_match else None
 
             with tempfile.NamedTemporaryFile() as temp_pdf:
                 # download pdf

--- a/src/menu_parser.py
+++ b/src/menu_parser.py
@@ -168,9 +168,11 @@ class FMIBistroMenuParser(MenuParser):
             return None
 
         # Example PDF-name: Garching-Speiseplan_KW46_2017.pdf
+        # more examples: https://regex101.com/r/ATOHj3/1/
         pdf_name = pdf_url.split("/")[-1]
-        year = int(pdf_name.split("_")[-1].split(".")[0])
-        week_number = int(pdf_name.split("_")[2].replace("KW","").lstrip("0"))
+        wn_year_match = re.search("KW[^a-zA-Z1-9]*([1-9]+\d*)[^a-zA-Z1-9]*([1-9]+\d*)", pdf_name, re.IGNORECASE)
+        week_number = int(wn_year_match.group(1)) if wn_year_match else None
+        year = int(wn_year_match.group(2)) if wn_year_match else None
 
         with tempfile.NamedTemporaryFile() as temp_pdf:
             # download pdf


### PR DESCRIPTION
Will now also use a regex for getting the week number/year out of the PDF name.

You will need that for next week or you will get:

    ValueError: invalid literal for int() with base 10: '7\xad'

(There is a strange spacial character beween the `7` and `_` `KW-7%C2%AD_12.02.-16.02.2018.pdf`)

Note that the program will still throw an error after this PR. I think the reason is that the parser is confused with the empty column on Wednesday (Aschermittwoch).