### PR TITLE
Parse Menus to OpenMensa XML Format

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The JSON files are produced by the tool shown in this repository. Hence, it is e
 
 ```
 $ python src/main.py -h
-usage: main.py [-h] [-d DATE] [-j PATH] [-c]
+usage: main.py [-h] [-d DATE] [-j PATH] [-c] [--openmensa PATH]
                {fmi-bistro,ipp-bistro,mensa-garching,stucafe-karlstr,mensa-pasing,mensa-arcisstr,stucafe-boltzmannstr,stubistro-arcisstr,stucafe-garching,mensa-martinsried,mensa-weihenstephan,stubistro-grosshadern,stucafe-akademie-weihenstephan,mensa-lothstr,stubistro-goethestr,stubistro-großhadern,mensa-arcisstrasse,stucafe-pasing,stubistro-rosenheim,stucafe-adalbertstr,stubistro-schellingstr,mensa-leopoldstr}
 
 positional arguments:
@@ -60,7 +60,8 @@ optional arguments:
                         ignored if this argument is used)
   -c, --combine         creates a "combined.json" file containing all dishes
                         for the location specified
-
+  --openmensa PATH      directory for OpenMensa XML output (date parameter
+                        will be ignored if this argument is used)
 ```
 
 It is mandatory to specify the canteen (e.g. mensa-garching). Furthermore, you can specify a date, for which you would like to get the menu. If no date is provided, all the dishes for the current week will be printed to the command line. the `--jsonify` option is used for the API and produces some JSON files containing the menu data. 

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ requests==2.12.4
 six==1.10.0
 tabulate==0.7.7
 yarg==0.1.9
+pyopenmensa==0.95.0

--- a/scripts/parse.sh
+++ b/scripts/parse.sh
@@ -13,4 +13,10 @@ for loc in "${loc_list[@]}"; do
     python src/main.py "$loc" --jsonify "./dist/$loc"
 done
 
+openmensa_list=( "ipp-bistro" "fmi-bistro" )
+
+for loc in "${openmensa_list[@]}"; do
+    python src/main.py "$loc" --openmensa "./dist/$loc"
+done
+
 tree dist/

--- a/src/cli.py
+++ b/src/cli.py
@@ -16,5 +16,8 @@ def parse_cli_args():
                         metavar="PATH")
     parser.add_argument('-c', '--combine', action='store_true',
                         help='creates a "combined.json" file containing all dishes for the location specified')
+    parser.add_argument('--openmensa', 
+                        help="directory for OpenMensa XML output (date parameter will be ignored if this argument is used)",
+                        metavar="PATH")
     args = parser.parse_args()
     return args

--- a/src/main.py
+++ b/src/main.py
@@ -6,6 +6,7 @@ import cli
 import menu_parser
 
 import util
+from openmensa import openmensa
 from entities import Week
 
 
@@ -96,6 +97,11 @@ def main():
         if not os.path.exists(args.jsonify):
             os.makedirs(args.jsonify)
         jsonify(weeks, args.jsonify, location, args.combine)
+    elif args.openmensa is not None:
+        weeks = Week.to_weeks(menus)
+        if not os.path.exists(args.openmensa):
+            os.makedirs(args.openmensa)
+        openmensa(weeks, args.openmensa)
     # date argument is set
     elif args.date is not None:
         if menu_date not in menus:

--- a/src/openmensa.py
+++ b/src/openmensa.py
@@ -1,0 +1,25 @@
+from pyopenmensa.feed import LazyBuilder
+from datetime import date
+
+def openmensa(weeks, directory):
+    canteen = LazyBuilder() # canteen container
+    # iterate through weeks
+    for calendar_week in weeks:
+        # get Week object
+        week = weeks[calendar_week]
+        # get year of calendar week
+        days = week.days
+
+        # iterate through days
+        for menu in days:
+
+            # iterate through dishes
+            for dish in menu.dishes:
+                if type(dish.price) is float:
+                    prices = {'other': dish.price}
+                else:
+                    prices = {}
+                canteen.addMeal(menu.menu_date, 'Speiseplan', dish.name, prices=prices)
+
+    with open("%s/feed.xml" % (str(directory)), 'w') as outfile:
+            outfile.write(canteen.toXMLFeed())

--- a/src/openmensa.py
+++ b/src/openmensa.py
@@ -2,6 +2,11 @@ from pyopenmensa.feed import LazyBuilder
 from datetime import date
 
 def openmensa(weeks, directory):
+    canteen = weeksToCanteenFeed(weeks)
+
+    writeFeedToFile(canteen, directory)
+
+def weeksToCanteenFeed(weeks):
     canteen = LazyBuilder() # canteen container
     # iterate through weeks
     for calendar_week in weeks:
@@ -15,11 +20,17 @@ def openmensa(weeks, directory):
 
             # iterate through dishes
             for dish in menu.dishes:
-                if type(dish.price) is float:
-                    prices = {'other': dish.price}
-                else:
-                    prices = {}
-                canteen.addMeal(menu.menu_date, 'Speiseplan', dish.name, prices=prices)
+                addDishToCanteen(dish, menu.menu_date, canteen)
 
+    return canteen
+
+def addDishToCanteen(dish, date, canteen):
+    if type(dish.price) is float:
+        prices = {'other': dish.price}
+    else:
+        prices = {}
+    canteen.addMeal(date, 'Speiseplan', dish.name, prices=prices)
+
+def writeFeedToFile(canteen, directory):
     with open("%s/feed.xml" % (str(directory)), 'w') as outfile:
-            outfile.write(canteen.toXMLFeed())
+        outfile.write(canteen.toXMLFeed())

--- a/src/test/test_openmensa.py
+++ b/src/test/test_openmensa.py
@@ -1,0 +1,64 @@
+from unittest import TestCase
+from pyopenmensa.feed import LazyBuilder
+from datetime import date
+from menu_parser import FMIBistroMenuParser
+from entities import Dish, Menu, Week
+import openmensa
+
+class OpenMensaTest(TestCase):
+    def test_Should_Add_Dish_to_Canteen(self):
+        canteen = LazyBuilder()
+        dateobj = date(2017, 3, 27)
+        dish = Dish("Gulasch vom Schwein", 1.9)
+
+        openmensa.addDishToCanteen(dish, dateobj, canteen)
+        meal = canteen._days[dateobj]['Speiseplan'][0]
+        self.assertEqual(meal[0], "Gulasch vom Schwein")
+        self.assertEqual(meal[2], {'other': 190})
+
+    def test_Should_Add_Week_to_Canteen(self):
+        date_mon2 = date(2017, 11, 6)
+        date_tue2 = date(2017, 11, 7)
+        date_wed2 = date(2017, 11, 8)
+        date_thu2 = date(2017, 11, 9)
+        date_fri2 = date(2017, 11, 10)
+        dish_aktion2 = Dish("Pochiertes Lachsfilet mit Dillsoße dazu Minze-Reis", 6.5)
+        dish1_mon2 = Dish("Dampfkartoffeln mit Zucchinigemüse", 3.6)
+        dish2_mon2 = Dish("Valess-Schnitzel mit Tomaten-Couscous", 4.3)
+        dish3_mon2 = Dish("Kasslerpfanne mit frischen Champignons und Spätzle", 4.9)
+        dish1_tue2 = Dish("Gemüsereispfanne mit geräuchertem Tofu", 3.6)
+        dish2_tue2 = Dish("Schweineschnitzel in Karottenpanade mit Rosmarin- Risoleekartoffeln", 5.3)
+        dish1_wed2 = Dish("Spaghetti al Pomodoro", 3.6)
+        dish2_wed2 = Dish("Krustenbraten vom Schwein mit Kartoffelknödel und Krautsalat", 5.3)
+        dish1_thu2 = Dish("Red-Thaicurrysuppe mit Gemüse und Kokosmilch", 2.9)
+        dish2_thu2 = Dish("Senf-Eier mit Salzkartoffeln", 3.8)
+        dish3_thu2 = Dish("Putengyros mit Zaziki und Tomatenreis", 5.3)
+        dish1_fri2 = Dish("Spiralnudeln mit Ratatouillegemüse", 3.6)
+        dish2_fri2 = Dish("Milchreis mit warmen Sauerkirschen", 3)
+        dish3_fri2 = Dish("Lasagne aus Seelachs und Blattspinat", 5.3)
+        menu_mon2 = Menu(date_mon2, [dish_aktion2, dish1_mon2, dish2_mon2, dish3_mon2])
+        menu_tue2 = Menu(date_tue2, [dish_aktion2, dish1_tue2, dish2_tue2])
+        menu_wed2 = Menu(date_wed2, [dish_aktion2, dish1_wed2, dish2_wed2])
+        menu_thu2 = Menu(date_thu2, [dish_aktion2, dish1_thu2, dish2_thu2, dish3_thu2])
+        menu_fri2 = Menu(date_fri2, [dish_aktion2, dish1_fri2, dish2_fri2, dish3_fri2])
+        week = Week(45, 2017, [menu_mon2, menu_tue2, menu_wed2, menu_thu2, menu_fri2])
+        week = {}
+        week[date_mon2] = menu_mon2
+        week[date_tue2] = menu_tue2
+        week[date_wed2] = menu_wed2
+        week[date_thu2] = menu_thu2
+        week[date_fri2] = menu_fri2
+        weeks = Week.to_weeks(week)
+
+        canteen = openmensa.weeksToCanteenFeed(weeks)
+        self.assertEqual(canteen.hasMealsFor(date_mon2), True)
+        self.assertEqual(canteen.hasMealsFor(date_tue2), True)
+        self.assertEqual(canteen.hasMealsFor(date_wed2), True)
+        self.assertEqual(canteen.hasMealsFor(date_thu2), True)
+        self.assertEqual(canteen.hasMealsFor(date_fri2), True)
+        
+        canteen_wed2 = canteen._days[date_wed2]['Speiseplan']
+        self.assertEqual(canteen_wed2[0], ("Pochiertes Lachsfilet mit Dillsoße dazu Minze-Reis", [], {'other': 650}))
+        self.assertEqual(canteen_wed2[1], ("Spaghetti al Pomodoro", [], {'other': 360}))
+        self.assertEqual(canteen_wed2[2], ("Krustenbraten vom Schwein mit Kartoffelknödel und Krautsalat", [], {'other': 530}))
+        


### PR DESCRIPTION
Report FMI and IPP Menus to [OpenMensa Project](https://openmensa.org).

They read XML Feeds as described here: http://doc.openmensa.org/feed/v2/
and here:https://openmensa.org/contribute

XML Generation is done my [pyopenmensa](https://pypi.python.org/pypi/pyopenmensa) which is done by @mswart who created @openmensa if I got it right.

This PR could be improved by:

- [ ] Providing prices in different categories
- [ ] Providing correct Menu Category (e.g. for FMI) instead of hardcoding "Speiseplan"
- [x] Unit Tests (e.g. validating xml)

Help and feedback welcome!
There is a follow up PR #26  which adds [Meta data](http://doc.openmensa.org/feed/v2/#meta-data-since-version-21) XML files to `gh-pages` branch linking each locations feed xml file.