### PR TITLE
FMI Fixing get PDF failed due to new <strong> tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Simple static API for the canteens of the [Studentenwerk München](http://www.st
 | StuCafé Karlstraße             | stucafe-karlstr                | [Karlstraße 6, München](https://www.google.com/maps?q=Karlstraße+6,+München)                                           |
 | StuCafé Pasing                 | stucafe-pasing                 | [Am Stadtpark 20, München](https://www.google.com/maps?q=Am%20Stadtpark+20,+München)                                     |
 | FMI Bistro Garching            | fmi-bistro                     | [Boltzmannstraße 3, Garching](https://www.google.com/maps?q=Boltzmannstraße+3,+Garching)                   |
-| IPP Bistro Garching            | ipp-bistro                     | [Boltzmannstraße 2, Garching](https://www.google.com/maps?q=Boltzmannstraße+2,+Garching)                   |
+| IPP Bistro Garching            | ipp-bistro                     | [Boltzmannstraße 2, Garching](https://goo.gl/maps/vYdsQhgxFvH2)                   |
 
 ## Usage
 
@@ -66,7 +66,7 @@ optional arguments:
                         will be ignored if this argument is used)
 ```
 
-It is mandatory to specify the canteen (e.g. mensa-garching). Furthermore, you can specify a date, for which you would like to get the menu. If no date is provided, all the dishes for the current week will be printed to the command line. the `--jsonify` option is used for the API and produces some JSON files containing the menu data. 
+It is mandatory to specify the canteen (e.g. mensa-garching). Furthermore, you can specify a date, for which you would like to get the menu. If no date is provided, all the dishes for the current week will be printed to the command line. the `--jsonify` option is used for the API and produces some JSON files containing the menu data.
 
 #### Example
 Here are some sample calls:

--- a/README.md
+++ b/README.md
@@ -4,26 +4,28 @@
 
 Simple static API for the canteens of the [Studentenwerk München](http://www.studentenwerk-muenchen.de) as well as some other locations. By now, the following locations are supported:
 
- - Mensa Arcisstraße (mensa-arcisstr), Arcisstraße 17, München
- - Mensa Garching (mensa-garching), Lichtenbergstraße 2, Garching
- - Mensa Leopoldstraße (mensa-leopoldstr), Leopoldstraße 13a, München
- - Mensa Lothstraße (mensa-lothstr), Lothstraße 13d, München
- - Mensa Martinsried (mensa-martinsried), Großhaderner Straße 6, Planegg-Martinsried
- - Mensa Pasing (mensa-pasing), Am Stadtpark 20, München
- - Mensa Weihenstephan (mensa-weihenstephan), Maximus-von-Imhof-Forum 5, Freising
- - StuBistro Arcisstraße (stubistro-arcisstr), Arcisstraße 12, München
- - StuBistro Goethestraße (stubistro-goethestr), Goethestraße 70, München
- - StuBistro Großhadern (stubistro-grosshadern), Butenandtstraße 13, Gebäude F, München
- - StuBistro Rosenheim (stubistro-rosenheim), Hochschulstraße 1, Rosenheim
- - StuBistro Schellingstraße (stubistro-schellingstr), Schellingstraße 3, München
- - StuCafé Adalbertstraße (stucafe-adalbertstr), Adalbertstraße 5, München
- - StuCafé Akademie Weihenstephan (stucafe-akademie-weihenstephan), Alte Akademie 1, Freising
- - StuCafé Boltzmannstraße (stucafe-boltzmannstr), Boltzmannstraße 15, Garching
- - StuCafé in der Mensa Garching (stucafe-garching), Lichtenbergstraße 2, Garching
- - StuCafé Karlstraße (stucafe-karlstr), Karlstraße 6, München
- - StuCafé Pasing (stucafe-pasing), Am Stadtpark 20, München
- - FMI Bistro Garching (fmi-bistro), Boltzmannstraße 3, 85748 Garching
- - IPP Bistro Garching (ipp-bistro), Boltzmannstraße 2, 85748 Garching
+| Name                           | API-key                        | Address location                                                                                                       |
+|:-------------------------------|:-------------------------------|:-----------------------------------------------------------------------------------------------------------------------|
+| Mensa Arcisstraße              | mensa-arcisstr                 | [Arcisstraße 17, München](https://www.google.com/maps?q=Arcisstraße+17,+München)                                       |
+| Mensa Garching                 | mensa-garching                 | [Lichtenbergstraße 2, Garching](https://www.google.com/maps?q=Lichtenbergstraße+2,+Garching)                           |
+| Mensa Leopoldstraße            | mensa-leopoldstr               | [Leopoldstraße 13a, München](https://www.google.com/maps?q=Leopoldstraße+13a,+München)                                 |
+| Mensa Lothstraße               | mensa-lothstr                  | [Lothstraße 13d, München](https://www.google.com/maps?q=Lothstraße+13d,+München)                                       |
+| Mensa Martinsried              | mensa-martinsried              | [Großhaderner Straße 6, Planegg-Martinsried](https://www.google.com/maps?q=Großhaderner%20Straße+6,+Planegg-Martinsried) |
+| Mensa Pasing                   | mensa-pasing                   | [Am Stadtpark 20, München](https://www.google.com/maps?q=Am%20Stadtpark+20,+München)                                     |
+| Mensa Weihenstephan            | mensa-weihenstephan            | [Maximus-von-Imhof-Forum 5, Freising](https://www.google.com/maps?q=Maximus-von-Imhof-Forum+5,+Freising)               |
+| StuBistro Arcisstraße          | stubistro-arcisstr             | [Arcisstraße 12, München](https://www.google.com/maps?q=Arcisstraße+12,+München)                                       |
+| StuBistro Goethestraße         | stubistro-goethestr            | [Goethestraße 70, München](https://www.google.com/maps?q=Goethestraße+70,+München)                                     |
+| StuBistro Großhadern           | stubistro-grosshadern          | [Butenandtstraße 13, Gebäude F, München](https://www.google.com/maps?q=Butenandtstraße+13,+Gebäude+F,+München)         |
+| StuBistro Rosenheim            | stubistro-rosenheim            | [Hochschulstraße 1, Rosenheim](https://www.google.com/maps?q=Hochschulstraße+1,+Rosenheim)                             |
+| StuBistro Schellingstraße      | stubistro-schellingstr         | [Schellingstraße 3, München](https://www.google.com/maps?q=Schellingstraße+3,+München)                                 |
+| StuCafé Adalbertstraße         | stucafe-adalbertstr            | [Adalbertstraße 5, München](https://www.google.com/maps?q=Adalbertstraße+5,+München)                                   |
+| StuCafé Akademie Weihenstephan | stucafe-akademie-weihenstephan | [Alte Akademie 1, Freising](https://www.google.com/maps?q=Alte%20Akademie+1,+Freising)                                   |
+| StuCafé Boltzmannstraße        | stucafe-boltzmannstr           | [Boltzmannstraße 15, Garching](https://www.google.com/maps?q=Boltzmannstraße+15,+Garching)                             |
+| StuCafé in der Mensa Garching  | stucafe-garching               | [Lichtenbergstraße 2, Garching](https://www.google.com/maps?q=Lichtenbergstraße+2,+Garching)                           |
+| StuCafé Karlstraße             | stucafe-karlstr                | [Karlstraße 6, München](https://www.google.com/maps?q=Karlstraße+6,+München)                                           |
+| StuCafé Pasing                 | stucafe-pasing                 | [Am Stadtpark 20, München](https://www.google.com/maps?q=Am%20Stadtpark+20,+München)                                     |
+| FMI Bistro Garching            | fmi-bistro                     | [Boltzmannstraße 3, Garching](https://www.google.com/maps?q=Boltzmannstraße+3,+Garching)                   |
+| IPP Bistro Garching            | ipp-bistro                     | [Boltzmannstraße 2, Garching](https://www.google.com/maps?q=Boltzmannstraße+2,+Garching)                   |
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -86,3 +86,4 @@ $ python src/main.py mensa-arcisstrasse -d 02.04.2017
   - [Konradhofer Catering - Betriebskantine IPP](https://openmensa.org/c/774)
 - [Hunger | TUM.sexy](http://tum.sexy/hunger/) ([Github](https://github.com/mammuth/TUM.sexy))
 - `FMeat.php` SDK ([GitHub](https://github.com/jpbernius/fmeat.php))
+- [Telegram](https://telegram.org/) bot for [Channel t.me/lunchgfz](https://t.me/lunchgfz) ([GitLab](https://gitlab.com/raabf/lunchgfz-telegram))

--- a/src/menu_parser.py
+++ b/src/menu_parser.py
@@ -160,7 +160,7 @@ class FMIBistroMenuParser(MenuParser):
         # get html tree
         tree = html.fromstring(page.content)
         # get url of current pdf menu
-        xpath_query = tree.xpath("//a[contains(text(), 'Garching_Speiseplan')]/@href")
+        xpath_query = tree.xpath("//a[contains(@href, 'Speiseplan')]/@href")
 
         if len(xpath_query) < 1:
             return None

--- a/src/menu_parser.py
+++ b/src/menu_parser.py
@@ -277,8 +277,10 @@ class IPPBistroMenuParser(MenuParser):
         for pdf_url in xpath_query:
             # Example PDF-name: KW-48_27.11-01.12.10.2017-3.pdf
             pdf_name = pdf_url.split("/")[-1]
-            year = int(pdf_name.replace(".pdf","").split(".")[-1].split("-")[0])
-            week_number = int(pdf_name.split("_")[0].replace("KW-","").lstrip("0"))
+            # more examples: https://regex101.com/r/hwdpFx/1
+            wn_year_match = re.search("KW[^a-zA-Z1-9]*([1-9]+\d*).*\d+\.\d+\.(\d+).*", pdf_name, re.IGNORECASE)
+            week_number = int(wn_year_match.group(1)) if wn_year_match else None
+            year = int(wn_year_match.group(2)) if wn_year_match else None
 
             with tempfile.NamedTemporaryFile() as temp_pdf:
                 # download pdf

--- a/src/menu_parser.py
+++ b/src/menu_parser.py
@@ -168,9 +168,11 @@ class FMIBistroMenuParser(MenuParser):
             return None
 
         # Example PDF-name: Garching-Speiseplan_KW46_2017.pdf
+        # more examples: https://regex101.com/r/ATOHj3/1/
         pdf_name = pdf_url.split("/")[-1]
-        year = int(pdf_name.split("_")[-1].split(".")[0])
-        week_number = int(pdf_name.split("_")[2].replace("KW","").lstrip("0"))
+        wn_year_match = re.search("KW[^a-zA-Z1-9]*([1-9]+\d*)[^a-zA-Z1-9]*([1-9]+\d*)", pdf_name, re.IGNORECASE)
+        week_number = int(wn_year_match.group(1)) if wn_year_match else None
+        year = int(wn_year_match.group(2)) if wn_year_match else None
 
         with tempfile.NamedTemporaryFile() as temp_pdf:
             # download pdf

--- a/src/menu_parser.py
+++ b/src/menu_parser.py
@@ -174,6 +174,15 @@ class FMIBistroMenuParser(MenuParser):
             week_number = int(wn_year_match.group(1)) if wn_year_match else None
             year = int(wn_year_match.group(2)) if wn_year_match else None
 
+            today = datetime.today()
+            # a hacky way to detect when something is appended or prepended to the year (like 20181 for year 2018)
+            # TODO probably replace year abnormality by a better method
+            if year != today.year and str(today.year) in str(year):
+                year = today.year
+            elif year != today.year + 1 and str(today.year + 1) in str(year + 1):
+                # checking also next year when it is december
+                year = today.year + 1
+
             with tempfile.NamedTemporaryFile() as temp_pdf:
                 # download pdf
                 response = requests.get(pdf_url)


### PR DESCRIPTION
The FMI has added a new `strong` tag to the text of the `a` tag:

````html
    <a href="https://www.wilhelm-gastronomie.de/wpcontent/uploads/2018/04/Garching_Speiseplan_KW_19_2018.pdf"> 
        <strong>Garching_Speiseplan_KW_19_2018</strong>
    </a>
````

As a result the xpath do not find the link any more. Well we could implement the new `strong` node, but it migtht will be removed again. So, instead i seach for `Speiseplan` in the href instead of the text, which works quite well.