### PR TITLE
Closed days fix ipp

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Simple static API for the canteens of the [Studentenwerk München](http://www.st
 | StuCafé Karlstraße             | stucafe-karlstr                | [Karlstraße 6, München](https://www.google.com/maps?q=Karlstraße+6,+München)                                           |
 | StuCafé Pasing                 | stucafe-pasing                 | [Am Stadtpark 20, München](https://www.google.com/maps?q=Am%20Stadtpark+20,+München)                                     |
 | FMI Bistro Garching            | fmi-bistro                     | [Boltzmannstraße 3, Garching](https://www.google.com/maps?q=Boltzmannstraße+3,+Garching)                   |
-| IPP Bistro Garching            | ipp-bistro                     | [Boltzmannstraße 2, Garching](https://www.google.com/maps?q=Boltzmannstraße+2,+Garching)                   |
+| IPP Bistro Garching            | ipp-bistro                     | [Boltzmannstraße 2, Garching](https://goo.gl/maps/vYdsQhgxFvH2)                   |
 
 ## Usage
 
@@ -66,7 +66,7 @@ optional arguments:
                         will be ignored if this argument is used)
 ```
 
-It is mandatory to specify the canteen (e.g. mensa-garching). Furthermore, you can specify a date, for which you would like to get the menu. If no date is provided, all the dishes for the current week will be printed to the command line. the `--jsonify` option is used for the API and produces some JSON files containing the menu data. 
+It is mandatory to specify the canteen (e.g. mensa-garching). Furthermore, you can specify a date, for which you would like to get the menu. If no date is provided, all the dishes for the current week will be printed to the command line. the `--jsonify` option is used for the API and produces some JSON files containing the menu data.
 
 #### Example
 Here are some sample calls:

--- a/README.md
+++ b/README.md
@@ -4,26 +4,28 @@
 
 Simple static API for the canteens of the [Studentenwerk München](http://www.studentenwerk-muenchen.de) as well as some other locations. By now, the following locations are supported:
 
- - Mensa Arcisstraße (mensa-arcisstr), Arcisstraße 17, München
- - Mensa Garching (mensa-garching), Lichtenbergstraße 2, Garching
- - Mensa Leopoldstraße (mensa-leopoldstr), Leopoldstraße 13a, München
- - Mensa Lothstraße (mensa-lothstr), Lothstraße 13d, München
- - Mensa Martinsried (mensa-martinsried), Großhaderner Straße 6, Planegg-Martinsried
- - Mensa Pasing (mensa-pasing), Am Stadtpark 20, München
- - Mensa Weihenstephan (mensa-weihenstephan), Maximus-von-Imhof-Forum 5, Freising
- - StuBistro Arcisstraße (stubistro-arcisstr), Arcisstraße 12, München
- - StuBistro Goethestraße (stubistro-goethestr), Goethestraße 70, München
- - StuBistro Großhadern (stubistro-grosshadern), Butenandtstraße 13, Gebäude F, München
- - StuBistro Rosenheim (stubistro-rosenheim), Hochschulstraße 1, Rosenheim
- - StuBistro Schellingstraße (stubistro-schellingstr), Schellingstraße 3, München
- - StuCafé Adalbertstraße (stucafe-adalbertstr), Adalbertstraße 5, München
- - StuCafé Akademie Weihenstephan (stucafe-akademie-weihenstephan), Alte Akademie 1, Freising
- - StuCafé Boltzmannstraße (stucafe-boltzmannstr), Boltzmannstraße 15, Garching
- - StuCafé in der Mensa Garching (stucafe-garching), Lichtenbergstraße 2, Garching
- - StuCafé Karlstraße (stucafe-karlstr), Karlstraße 6, München
- - StuCafé Pasing (stucafe-pasing), Am Stadtpark 20, München
- - FMI Bistro Garching (fmi-bistro), Boltzmannstraße 3, 85748 Garching
- - IPP Bistro Garching (ipp-bistro), Boltzmannstraße 2, 85748 Garching
+| Name                           | API-key                        | Address location                                                                                                       |
+|:-------------------------------|:-------------------------------|:-----------------------------------------------------------------------------------------------------------------------|
+| Mensa Arcisstraße              | mensa-arcisstr                 | [Arcisstraße 17, München](https://www.google.com/maps?q=Arcisstraße+17,+München)                                       |
+| Mensa Garching                 | mensa-garching                 | [Lichtenbergstraße 2, Garching](https://www.google.com/maps?q=Lichtenbergstraße+2,+Garching)                           |
+| Mensa Leopoldstraße            | mensa-leopoldstr               | [Leopoldstraße 13a, München](https://www.google.com/maps?q=Leopoldstraße+13a,+München)                                 |
+| Mensa Lothstraße               | mensa-lothstr                  | [Lothstraße 13d, München](https://www.google.com/maps?q=Lothstraße+13d,+München)                                       |
+| Mensa Martinsried              | mensa-martinsried              | [Großhaderner Straße 6, Planegg-Martinsried](https://www.google.com/maps?q=Großhaderner%20Straße+6,+Planegg-Martinsried) |
+| Mensa Pasing                   | mensa-pasing                   | [Am Stadtpark 20, München](https://www.google.com/maps?q=Am%20Stadtpark+20,+München)                                     |
+| Mensa Weihenstephan            | mensa-weihenstephan            | [Maximus-von-Imhof-Forum 5, Freising](https://www.google.com/maps?q=Maximus-von-Imhof-Forum+5,+Freising)               |
+| StuBistro Arcisstraße          | stubistro-arcisstr             | [Arcisstraße 12, München](https://www.google.com/maps?q=Arcisstraße+12,+München)                                       |
+| StuBistro Goethestraße         | stubistro-goethestr            | [Goethestraße 70, München](https://www.google.com/maps?q=Goethestraße+70,+München)                                     |
+| StuBistro Großhadern           | stubistro-grosshadern          | [Butenandtstraße 13, Gebäude F, München](https://www.google.com/maps?q=Butenandtstraße+13,+Gebäude+F,+München)         |
+| StuBistro Rosenheim            | stubistro-rosenheim            | [Hochschulstraße 1, Rosenheim](https://www.google.com/maps?q=Hochschulstraße+1,+Rosenheim)                             |
+| StuBistro Schellingstraße      | stubistro-schellingstr         | [Schellingstraße 3, München](https://www.google.com/maps?q=Schellingstraße+3,+München)                                 |
+| StuCafé Adalbertstraße         | stucafe-adalbertstr            | [Adalbertstraße 5, München](https://www.google.com/maps?q=Adalbertstraße+5,+München)                                   |
+| StuCafé Akademie Weihenstephan | stucafe-akademie-weihenstephan | [Alte Akademie 1, Freising](https://www.google.com/maps?q=Alte%20Akademie+1,+Freising)                                   |
+| StuCafé Boltzmannstraße        | stucafe-boltzmannstr           | [Boltzmannstraße 15, Garching](https://www.google.com/maps?q=Boltzmannstraße+15,+Garching)                             |
+| StuCafé in der Mensa Garching  | stucafe-garching               | [Lichtenbergstraße 2, Garching](https://www.google.com/maps?q=Lichtenbergstraße+2,+Garching)                           |
+| StuCafé Karlstraße             | stucafe-karlstr                | [Karlstraße 6, München](https://www.google.com/maps?q=Karlstraße+6,+München)                                           |
+| StuCafé Pasing                 | stucafe-pasing                 | [Am Stadtpark 20, München](https://www.google.com/maps?q=Am%20Stadtpark+20,+München)                                     |
+| FMI Bistro Garching            | fmi-bistro                     | [Boltzmannstraße 3, Garching](https://www.google.com/maps?q=Boltzmannstraße+3,+Garching)                   |
+| IPP Bistro Garching            | ipp-bistro                     | [Boltzmannstraße 2, Garching](https://www.google.com/maps?q=Boltzmannstraße+2,+Garching)                   |
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -86,3 +86,4 @@ $ python src/main.py mensa-arcisstrasse -d 02.04.2017
   - [Konradhofer Catering - Betriebskantine IPP](https://openmensa.org/c/774)
 - [Hunger | TUM.sexy](http://tum.sexy/hunger/) ([Github](https://github.com/mammuth/TUM.sexy))
 - `FMeat.php` SDK ([GitHub](https://github.com/jpbernius/fmeat.php))
+- [Telegram](https://telegram.org/) bot for [Channel t.me/lunchgfz](https://t.me/lunchgfz) ([GitLab](https://gitlab.com/raabf/lunchgfz-telegram))

--- a/src/menu_parser.py
+++ b/src/menu_parser.py
@@ -160,7 +160,7 @@ class FMIBistroMenuParser(MenuParser):
         # get html tree
         tree = html.fromstring(page.content)
         # get url of current pdf menu
-        xpath_query = tree.xpath("//a[contains(text(), 'Garching_Speiseplan')]/@href")
+        xpath_query = tree.xpath("//a[contains(@href, 'Speiseplan')]/@href")
 
         if len(xpath_query) < 1:
             return None

--- a/src/menu_parser.py
+++ b/src/menu_parser.py
@@ -354,8 +354,6 @@ class IPPBistroMenuParser(MenuParser):
         pos_thu = positions[3][0]
         pos_fri = positions[4][0]
 
-        print(pos_mon, pos_tue, pos_wed, pos_fri)
-
         lines_weekdays = {"mon": "", "tue": "", "wed": "", "thu": "", "fri": ""}
         # it must be lines[3:] instead of lines[2:] or else the menus would start with "Preis ab 0,90€" (from the
         # soups) instead of the first menu, if there is a day where the bistro is closed.

--- a/src/menu_parser.py
+++ b/src/menu_parser.py
@@ -286,7 +286,7 @@ class FMIBistroMenuParser(MenuParser):
 class IPPBistroMenuParser(MenuParser):
     url = "http://konradhof-catering.de/ipp/"
     weekday_positions = {"mon": 1, "tue": 2, "wed": 3, "thu": 4, "fri": 5}
-    split_days_regex = r'(Tagessuppe siehe Aushang|Aschermittwoch)'
+    split_days_regex = r'(Tagessuppe siehe Aushang|Aschermittwoch|Feiertag|Geschlossen)'
     price_regex = r"\d+,\d+\s\€[^\)]"
     dish_regex = r".+?\d+,\d+\s\€[^\)]"
 
@@ -342,10 +342,11 @@ class IPPBistroMenuParser(MenuParser):
         weekdays = lines[0]
         lines = lines[3:]
 
-        positions = [(a.start(), a.end()) for a in list(re.finditer(self.split_days_regex, lines[0]))]
-        if len(positions) != 5:
-            # TODO handle special cases (e.g. that bistro is closed)
-            return None
+        positions1 = [(a.start(), a.end()) for a in list(re.finditer(self.split_days_regex, lines[0]))]
+        # In the second line there might be information about closed days ("Geschlossen", "Feiertag")
+        positions2 = [(a.start(), a.end()) for a in list(re.finditer(self.split_days_regex, lines[1]))]
+
+        positions = sorted(positions1 + positions2)
 
         pos_mon = positions[0][0]
         pos_tue = positions[1][0]
@@ -353,8 +354,12 @@ class IPPBistroMenuParser(MenuParser):
         pos_thu = positions[3][0]
         pos_fri = positions[4][0]
 
+        print(pos_mon, pos_tue, pos_wed, pos_fri)
+
         lines_weekdays = {"mon": "", "tue": "", "wed": "", "thu": "", "fri": ""}
-        for line in lines[2:]:
+        # it must be lines[3:] instead of lines[2:] or else the menus would start with "Preis ab 0,90€" (from the
+        # soups) instead of the first menu, if there is a day where the bistro is closed.
+        for line in lines[3:]:
             lines_weekdays["mon"] += " " + line[pos_mon:pos_tue].replace("\n", " ")
             lines_weekdays["tue"] += " " + line[pos_tue:pos_wed].replace("\n", " ")
             lines_weekdays["wed"] += " " + line[pos_wed:pos_thu].replace("\n", " ")

--- a/src/menu_parser.py
+++ b/src/menu_parser.py
@@ -277,8 +277,10 @@ class IPPBistroMenuParser(MenuParser):
         for pdf_url in xpath_query:
             # Example PDF-name: KW-48_27.11-01.12.10.2017-3.pdf
             pdf_name = pdf_url.split("/")[-1]
-            year = int(pdf_name.replace(".pdf","").split(".")[-1].split("-")[0])
-            week_number = int(pdf_name.split("_")[0].replace("KW-","").lstrip("0"))
+            # more examples: https://regex101.com/r/hwdpFx/1
+            wn_year_match = re.search("KW[^a-zA-Z1-9]*([1-9]+\d*).*\d+\.\d+\.(\d+).*", pdf_name, re.IGNORECASE)
+            week_number = int(wn_year_match.group(1)) if wn_year_match else None
+            year = int(wn_year_match.group(2)) if wn_year_match else None
 
             with tempfile.NamedTemporaryFile() as temp_pdf:
                 # download pdf

--- a/src/menu_parser.py
+++ b/src/menu_parser.py
@@ -168,9 +168,11 @@ class FMIBistroMenuParser(MenuParser):
             return None
 
         # Example PDF-name: Garching-Speiseplan_KW46_2017.pdf
+        # more examples: https://regex101.com/r/ATOHj3/1/
         pdf_name = pdf_url.split("/")[-1]
-        year = int(pdf_name.split("_")[-1].split(".")[0])
-        week_number = int(pdf_name.split("_")[2].replace("KW","").lstrip("0"))
+        wn_year_match = re.search("KW[^a-zA-Z1-9]*([1-9]+\d*)[^a-zA-Z1-9]*([1-9]+\d*)", pdf_name, re.IGNORECASE)
+        week_number = int(wn_year_match.group(1)) if wn_year_match else None
+        year = int(wn_year_match.group(2)) if wn_year_match else None
 
         with tempfile.NamedTemporaryFile() as temp_pdf:
             # download pdf

--- a/src/menu_parser.py
+++ b/src/menu_parser.py
@@ -174,6 +174,15 @@ class FMIBistroMenuParser(MenuParser):
             week_number = int(wn_year_match.group(1)) if wn_year_match else None
             year = int(wn_year_match.group(2)) if wn_year_match else None
 
+            today = datetime.today()
+            # a hacky way to detect when something is appended or prepended to the year (like 20181 for year 2018)
+            # TODO probably replace year abnormality by a better method
+            if year != today.year and str(today.year) in str(year):
+                year = today.year
+            elif year != today.year + 1 and str(today.year + 1) in str(year + 1):
+                # checking also next year when it is december
+                year = today.year + 1
+
             with tempfile.NamedTemporaryFile() as temp_pdf:
                 # download pdf
                 response = requests.get(pdf_url)

--- a/src/test/assets/ipp/KW-18_30.04.-04.05.18.txt
+++ b/src/test/assets/ipp/KW-18_30.04.-04.05.18.txt
@@ -1,0 +1,57 @@
+                                                KONRADHOF CATERING - Betriebskantine IPP
+
+                                                   Speiseplan KW 18 - 30. April bis 04. Mai 2018
+
+                            Montag      Dienstag                           Mittwoch                                 Donnerstag                               Freitag
+
+
+                                                              Tagessuppe siehe Aushang                  Tagessuppe siehe Aushang               Tagessuppe siehe Aushang
+    Suppentopf         Geschlossen   Feiertag
+                                                                   Preis ab 0,90 €                           Preis ab 0,90 €                        Preis ab 0,90 €
+
+
+
+
+                                                                                                          Grenaillekartoffeln mit                   Curryreispfanne
+                                                                   Kirschmichel mit                        Apfel-Möhren-Quark,                   mit Gemüse, Ananas,
+      Veggie                                                         Vanillesauce                       auf Wunsch mit gerösteten               Kreuzkümmel, Koriander
+                                                                                                          Sonnenblumenkernen                         und Chili-Dip
+                                                                                               3,50 €                                 3,50 €                               3,50 €
+
+
+
+                                                                 Fitnessteak vom Grill,
+                                                                                                           Böfflamott, gebeizter                 Zitronen Seelachs auf
+                                                            dazu Zitrone oder Kräuterbutter,
+                                                                                                          Rinderschmorbraten mit                 Paprika-Champignon
+                                                             Grilltomate und Ofenkartoffel
+Traditionelle Küche                                                                                           Rotwein, dazu                      Gemüse, Petersilien-
+                                                                mit Sauerrahmdip oder
+                                                                                                           Frühlingsgemüse und                   Kartoffeln und leichter
+                                                                  bunter Salatauswahl
+                                                                                                              Semmelknödel                            Buttersauce
+                                                                                               8,20 €                                 6,80 €                               5,90 €
+
+
+
+
+                                                                     "Chana Dal"                                 Fussili mit
+                                                               Kichererbsen, Kartoffeln,                       Lauch, Ricotta,                 Paprikarahmgeschnetzeltes
+Internationale Küche                                           Kokosmilch, Curryblätter                       Meerrettich und                     mit Hörnchennudeln
+                                                                       und Reis                             frischem Basilikum
+                                                                                               4,90 €                                 4,50 €                               5,20 €
+
+
+
+
+                                                                Calamari alla Romana,                                                                  "Pasta Arora"
+                                                                                                              Aus dem Wok
+                                                              gebackene Tintenfischringe                                                         italienische Nudeln mit
+                                                                                                         Putengeschnetzeltes mit
+     Specials                                                 mit Knoblauchmayonnaise                                                          Tomatensahne, Mozzarella
+                                                                                                        Mangold, Möhren, Frühlings-
+                                                              und gemischtem Blattsalat                                                                und Basilikum
+                                                                                                         zwiebeln und Basmatireis
+                                                                mit Tomate und Gurke
+                                                                                               6,20 €                                 6,90 €                               4,50 €
+

--- a/src/test/assets/ipp/KW-19_07.05.-11.05.18.txt
+++ b/src/test/assets/ipp/KW-19_07.05.-11.05.18.txt
@@ -1,0 +1,55 @@
+                                                                              KONRADHOF CATERING - Betriebskantine IPP
+
+                                                                                      Speiseplan KW 19 - 07.Mai bis 11. Mai 2018
+
+                                    Montag                               Dienstag                               Mittwoch                   Donnerstag                  Freitag
+
+
+                       Tagessuppe siehe Aushang             Tagessuppe siehe Aushang                Tagessuppe siehe Aushang                            Tagessuppe siehe Aushang
+    Suppentopf                                                                                                                           Feiertag
+                            Preis ab 0,90 €                      Preis ab 0,90 €                         Preis ab 0,90 €                                     Preis ab 0,90 €
+
+
+
+
+                                                               Gebackener Edamer                          Italienische                                        Spaghetti mit
+                         Gemüse-Schupfnudeln
+      Veggie                                                     mit Rohkostsalat                        Minestrone mit                                     Tomatensauce und
+                          dazu Sauerrahm-Dip
+                                                                und Preiselbeeren                              Reis                                            Reibekäse
+
+                                                  3,50 €                                   4,90 €                               3,50 €                                                  3,50 €
+
+
+
+                               Würziger
+                                                                     Köttbullar                           Gebackenes                                              2 Paar
+                          Putenbrustbraten mit
+                                                                (Hackfleischbällchen)                   Schweineschnitzel                                     Schweinswürst´l
+Traditionelle Küche        Frühlingsgemüse
+                                                           mit Rahmsauce, Preiselbeeren                  mit Zitrone und                                      auf Sauerkraut
+                             und Kroketten
+                                                               und Petersilienkartoffeln                 Pommes frites                                          und Püree
+                                                  7,20 €                                   4,80 €                               5,90 €                                                  4,80 €
+
+
+
+                                                                                                       "Vegetarian Vindaloo"                            "Chicken Padam Pasanda"
+                                                               Burgunderbraten vom
+                            Gnocchi-Lauch                                                             Kartoffeln und Tomaten                              mit Nusssauce, Kokos-
+                                                                Rind mit Knödel und
+Internationale Küche          Gratin mit                                                             in Currysauce, dazu Reis                             flocken und indischen
+                                                                     Blaukraut
+                           Käse überbacken                                                             und frischer Koriander                                 Gewürzen, dazu
+                                                                                                                                                               Basmatireis
+                                                  4,80 €                                   6,20 €                               4,90 €                                                  6,90 €
+
+
+
+                            Schweinefleisch                                                            Farfalle "al Tonno"
+                               süß-sauer                           Quarkknödel                        mit Thunfisch, Kapern,                                   Kartoffeltasche,
+     Specials             mit Ananas, Paprika,                auf Erdbeer-Rhabarber                      Oliven, Tomaten                                gefüllt mit Kräuterfrischkäse
+                           Tomaten und Reis                          Kompott                              und Basilikum"                                    auf Paprikagemüse
+
+                                                  6,90 €                                   3,50 €                               4,90 €                                                  4,90 €
+

--- a/src/test/test_menu_parser.py
+++ b/src/test/test_menu_parser.py
@@ -154,7 +154,8 @@ class FMIBistroParserTest(unittest.TestCase):
     date_thu1 = date(2017, 11, 2)
     date_fri1 = date(2017, 11, 3)
 
-    dish_aktion1 = Dish("Tellerfleisch mit Bouillonkartoffeln und Sahnemeerrettich Kaiserschmarrn mit Zwetschenröster", 3.0)
+    dish_aktion1 = Dish("Tellerfleisch mit Bouillonkartoffeln und Sahnemeerrettich Kaiserschmarrn mit Zwetschenröster",
+                        3.0)
     dish1_mon1 = Dish("Kurkumareis mit Asia Wokgemüse", 3.6)
     dish2_mon1 = Dish("Kartoffel „Cordon Bleu“ mit Frischkäse gefüllt dazu Blattsalate", 4.3)
     dish3_mon1 = Dish("Putenschnitzel natur mit Paprikarahmsoße dazu Ebly Gemüseweizen", 5.3)
@@ -232,7 +233,7 @@ class IPPBistroParserTest(unittest.TestCase):
     dish2_tue1 = Dish("Jägerschnitzel mit Spätzle oder Reis", 4.8)
     dish3_tue1 = Dish("Vegetarisch gefüllte Tortelli mit leichter Zitronen-Buttersauce und gehobeltem Parmesan", 4.8)
     dish4_tue1 = Dish("\"Bami Goreng\" indonesische Bratnudeln mit Gemüse, Huhn, Schweinefleisch und Pilzen, " \
-                                   "dazu Honig-Chili- Dip", 6.9)
+                      "dazu Honig-Chili- Dip", 6.9)
     dish1_wed1 = Dish("Erbseneintopf (mit Wienerle 4,20 €)", 3.5)
     # TODO fix "B"
     dish2_wed1 = Dish("Hackbraten mit Zigeunersauce und Reis B", 4.8)
@@ -293,7 +294,7 @@ class IPPBistroParserTest(unittest.TestCase):
     menu_fri2 = Menu(date_fri2, [dish1_fri2, dish2_fri2, dish3_fri2, dish4_fri2])
 
     def test_Should_Return_Menu1(self):
-        menus_actual1  = self.ipp_parser.get_menus(self.test_menu1, self.year1, self.week_number1)
+        menus_actual1 = self.ipp_parser.get_menus(self.test_menu1, self.year1, self.week_number1)
         self.assertEqual(5, len(menus_actual1))
         self.assertEqual(self.menu_mon1, menus_actual1[self.date_mon1])
         self.assertEqual(self.menu_tue1, menus_actual1[self.date_tue1])
@@ -302,10 +303,114 @@ class IPPBistroParserTest(unittest.TestCase):
         self.assertEqual(self.menu_fri1, menus_actual1[self.date_fri1])
 
     def test_Should_Return_Menu2(self):
-        menus_actual2  = self.ipp_parser.get_menus(self.test_menu2, self.year2, self.week_number2)
+        menus_actual2 = self.ipp_parser.get_menus(self.test_menu2, self.year2, self.week_number2)
         self.assertEqual(5, len(menus_actual2))
         self.assertEqual(self.menu_mon2, menus_actual2[self.date_mon2])
         self.assertEqual(self.menu_tue2, menus_actual2[self.date_tue2])
         self.assertEqual(self.menu_wed2, menus_actual2[self.date_wed2])
         self.assertEqual(self.menu_thu2, menus_actual2[self.date_thu2])
         self.assertEqual(self.menu_fri2, menus_actual2[self.date_fri2])
+
+    ## Test Cases with holidays
+
+    ## Two holidays (Mon & Tue)
+
+    y18w18_date_mon = date(2018, 4, 30)
+    y18w18_date_tue = date(2018, 5, 1)
+    y18w18_date_wed = date(2018, 5, 2)
+    y18w18_date_thu = date(2018, 5, 3)
+    y18w18_date_fri = date(2018, 5, 4)
+
+    y18w18_dishes_wed = [
+        Dish("Kirschmichel mit Vanillesauce", 3.5),
+        Dish("Fitnessteak vom Grill, zu Zitrone oder Kräuterbutter, rilltomate und Ofenkartoffel mit "
+             "Sauerrahmdip oder bunter Salatauswahl", 8.2),
+        # TODO the correct Dish is the following, however this is a problem of the column width calculation.
+        # See https://github.com/srehwald/eat-api/issues/28
+        # Dish("Fitnessteak vom Grill, dazu Zitrone oder Kräuterbutter, Grilltomate und Ofenkartoffel mit "
+        #      "Sauerrahmdip oder bunter Salatauswahl", 8.2),
+        Dish("\"Chana Dal\" Kichererbsen, Kartoffeln, Kokosmilch, Curryblätter und Reis", 4.9),
+        Dish("Calamari alla Romana, gebackene Tintenfischringe mit Knoblauchmayonnaise und "
+             "gemischtem Blattsalat mit Tomate und Gurke", 6.2)
+    ]
+
+    y18w18_dishes_thu = [
+        Dish("Grenaillekartoffeln mit Apfel-Möhren-Quark, auf Wunsch mit gerösteten Sonnenblumenkernen", 3.5),
+        Dish("Böfflamott, gebeizter Rinderschmorbraten mit Rotwein, dazu Frühlingsgemüse und Semmelknödel", 6.8),
+        Dish("Fussili mit Lauch, Ricotta, Meerrettich und frischem Basilikum", 4.5),
+        Dish("Aus dem Wok Putengeschnetzeltes mit Mangold, Möhren, Frühlings- zwiebeln und Basmatireis", 6.9)]
+
+    y18w18_dishes_fri = [
+        Dish("Curryreispfanne mit Gemüse, Ananas, Kreuzkümmel, Koriander und Chili-Dip", 3.5),
+        Dish("Zitronen Seelachs auf Paprika-Champignon Gemüse, Petersilien- Kartoffeln und leichter Buttersauce", 5.90),
+        Dish("Paprikarahmgeschnetzeltes mit Hörnchennudeln", 5.2),
+        Dish("\"Pasta Arora\" italienische Nudeln mit Tomatensahne, Mozzarella und Basilikum", 4.5)]
+
+    y18w18_menu_mon = Menu(y18w18_date_mon, [])
+    y18w18_menu_tue = Menu(y18w18_date_tue, [])
+    y18w18_menu_wed = Menu(y18w18_date_wed, y18w18_dishes_wed)
+    y18w18_menu_thu = Menu(y18w18_date_thu, y18w18_dishes_thu)
+    y18w18_menu_fri = Menu(y18w18_date_fri, y18w18_dishes_fri)
+
+    y18w18_test_menu = open('src/test/assets/ipp/KW-18_30.04.-04.05.18.txt', 'r').read()
+
+    def test_Holiday_Should_Return_Menu_y18w18(self):
+        menus_actual = self.ipp_parser.get_menus(self.y18w18_test_menu, year=2018, week_number=18)
+        self.assertEqual(5, len(menus_actual))
+
+        self.assertEqual(self.y18w18_menu_mon, menus_actual[self.y18w18_date_mon])
+        self.assertEqual(self.y18w18_menu_tue, menus_actual[self.y18w18_date_tue])
+        self.assertEqual(self.y18w18_menu_wed, menus_actual[self.y18w18_date_wed])
+        self.assertEqual(self.y18w18_menu_thu, menus_actual[self.y18w18_date_thu])
+        self.assertEqual(self.y18w18_menu_fri, menus_actual[self.y18w18_date_fri])
+
+    ## One holiday (Thu)
+
+    y18w19_date_mon = date(2018, 5, 7)
+    y18w19_date_tue = date(2018, 5, 8)
+    y18w19_date_wed = date(2018, 5, 9)
+    y18w19_date_thu = date(2018, 5, 10)
+    y18w19_date_fri = date(2018, 5, 11)
+
+    y18w19_dishes_mon = [
+        Dish("Gemüse-Schupfnudeln dazu Sauerrahm-Dip", 3.5),
+        Dish("Würziger Putenbrustbraten mit Frühlingsgemüse m und Kroketten", 7.2),
+        Dish("Gnocchi-Lauch Gratin mit Käse überbacken", 4.8),
+        Dish("Schweinefleisch süß-sauer mit Ananas, Paprika, Tomaten und Reis", 6.9)]
+
+    y18w19_dishes_tue = [
+        Dish("Gebackener Edamer mit Rohkostsalat und Preiselbeeren", 4.9),
+        Dish("Köttbullar (Hackfleischbällchen) it Rahmsauce, Preiselbeeren und Petersilienkartoffeln", 4.8),
+        Dish("Burgunderbraten vom Rind mit Knödel und Blaukraut", 6.2),
+        Dish("Quarkknödel auf Erdbeer-Rhabarber Kompott", 3.5)]
+
+    y18w19_dishes_wed = [
+        Dish("Italienische Minestrone mit Reis", 3.5),
+        Dish("Gebackenes Schweineschnitzel mit Zitrone und Pommes frites", 5.9),
+        Dish("\"Vegetarian Vindaloo\" Kartoffeln und Tomaten in Currysauce, dazu Reis und frischer Koriander", 4.9),
+        # Note the " after the Basilikum is correct since it is part of the PDF
+        Dish("Farfalle \"al Tonno\" mit Thunfisch, Kapern, Oliven, Tomaten und Basilikum\"", 4.9)]
+
+    y18w19_dishes_fri = [
+        Dish("Spaghetti mit Tomatensauce und Reibekäse", 3.5),
+        Dish("2 Paar Schweinswürst ́l auf Sauerkraut und Püree", 4.8),
+        Dish("\"Chicken Padam Pasanda\" mit Nusssauce, Kokos- flocken und indischen Gewürzen, dazu Basmatireis", 6.9),
+        Dish("Kartoffeltasche, gefüllt mit Kräuterfrischkäse auf Paprikagemüse", 4.9)]
+
+    y18w19_menu_mon = Menu(y18w19_date_mon, y18w19_dishes_mon)
+    y18w19_menu_tue = Menu(y18w19_date_tue, y18w19_dishes_tue)
+    y18w19_menu_wed = Menu(y18w19_date_wed, y18w19_dishes_wed)
+    y18w19_menu_thu = Menu(y18w19_date_thu, [])
+    y18w19_menu_fri = Menu(y18w19_date_fri, y18w19_dishes_fri)
+
+    y18w19_test_menu = open('src/test/assets/ipp/KW-19_07.05.-11.05.18.txt', 'r').read()
+
+    def test_Holiday_Should_Return_Menu_y18w19(self):
+        menus_actual = self.ipp_parser.get_menus(self.y18w19_test_menu, year=2018, week_number=19)
+        self.assertEqual(5, len(menus_actual))
+
+        self.assertEqual(self.y18w19_menu_mon, menus_actual[self.y18w19_date_mon])
+        self.assertEqual(self.y18w19_menu_tue, menus_actual[self.y18w19_date_tue])
+        self.assertEqual(self.y18w19_menu_wed, menus_actual[self.y18w19_date_wed])
+        self.assertEqual(self.y18w19_menu_thu, menus_actual[self.y18w19_date_thu])
+        self.assertEqual(self.y18w19_menu_fri, menus_actual[self.y18w19_date_fri])


### PR DESCRIPTION
This PR allows the parser to work when there are empty columns due to closed days.

I'm not sure, if pdf-to-text always correcty perserves the indents on multiple lines, but this fix works fine for my test files. It correctly detects all menus for all days which are non empty and those who are empty are correctly not created, so I think this fix works.

As test files I used the last two weeks, which were quite holiday intensive (see attachment), and luckily we can test this implementation the next weeks, which are full of holidays again.

[KW-18_30.04.-04.05.18.pdf](https://github.com/srehwald/eat-api/files/1996045/KW-18_30.04.-04.05.18.pdf)
[KW-19_07.05.-11.05.18.pdf](https://github.com/srehwald/eat-api/files/1996047/KW-19_07.05.-11.05.18.pdf)