### PR TITLE
Two line soup fix

### DIFF
--- a/src/test/assets/ipp/KW-36_-03.09.-07.09.2018_two_line_soup.txt
+++ b/src/test/assets/ipp/KW-36_-03.09.-07.09.2018_two_line_soup.txt
@@ -1,0 +1,64 @@
+                                                                                          KONRADHOF CATERING - Betriebskantine IPP
+
+                                                 Speiseplan KW                                                          36                                      Montag, 3. September 2018 bi s Freitag, 7. September 2018
+
+                                   Montag                                            Dienstag                                             Mittwoch                                               Donnerstag                                                     Freitag
+
+
+
+                          T agessuppe siehe                             T agessuppe siehe                                    T agessuppe siehe
+                                                                                                                                                                               T agessuppe siehe Aushang                                T agessuppe siehe Aushang
+   Suppentopf                  Aushang                                         Aushang                                              Aushang
+                                                                                                                                                                                         Preis ab 0,90 €                                          Preis ab 0,90 €
+                            Preis ab 0,90 €                                Preis ab 0,90 €                                      Preis ab 0,90 €
+
+
+
+                       Vollkornudeln in Kräuter-                                                                         Indischer Gewürzreis mit
+                                                                   Kürbis-Kartoffeleintopf mit                                                                                 Kartoffel-Broccoli-Auflauf mit                           Spaghetti mit T omatensauce
+      Veggie               Sahnesauce und                                                                                             Linsen
+                                                                                  Curry                                                                                         körnigem Frischkäse-Quark                                         und Reibekäse
+                          geriebenem Käse
+
+                                                        3,50 €                                              3,50 €                                               3,50 €                                                      3,50 €                                       3,50 €
+
+
+
+                       Hähnchengeschnetzeltes
+                                                                    Chicken Wings mit BBQ-                             Abgebräunter Leberkäse mit                                    Bandnudeln mit Pilz-                                        Seelachsfilet mit
+                           "Leipziger Art" in
+Traditionelle Küche                                                  Sauce, Cole Slaw Salat                                 Zwiebelschmelze und                               Kräutersauce, auf Wunsch mit                                   Zwiebelsenfsauce und
+                           Gemüserahm und
+                                                                             und Wedges                                          Kartoffelpüree                                             Reibekäse                                              Butterkartoffeln
+                           Hörnchennudeln
+                                                        5,60 €                                              4,90 €                                               4,50 €                                                      4,50 €                                       5,50 €
+
+
+
+                                                                   T hailändische Bratnudeln                                                                                                                                            Hähnchenkeulen "Cacciatore"
+                       Schnitzel "Wiener Art" mit                                                                       Marinierte Hähnchenspieße                             Indisches Makhani Hähnchen
+                                                                            mit Weißkohl,                                                                                                                                                   mit Zwiebeln, T omaten,
+Internationale Küche      Pommes frites und                                                                                  auf Wokgemüse mit                                mit Cashewnüsse, Ingwer und
+                                                                     Lauchzwiebeln, Möhren                                                                                                                                               Champignons und Rotwein,
+                             Preiselbeeren                                                                                         Basmatireis                                        Koriander und Reis
+                                                                            dazu Chili-Dip                                                                                                                                                            dazu Reis
+                                                        5,90 €                                              4,90 €                                               6,90 €                                                      6,90 €                                       5,80 €
+
+
+
+                                                                                                                       Schweinefilet Medaillons in
+                       Chili con carne, pikanter                                                                                                                                                                                          Rollbraten vom Schwein in
+                                                                   Gekochtes Rindfleisch mit                             grüner Pfefferrahmsauce
+                            mexikanischer                                                                                                                                          Pikantes Fischcurry mit                                     Kräutermarinade mit
+     Specials                                                             Salsa verde oder                                     mit Kroketten und
+                          Bohneneintopf mit                                                                                                                                     Basmatireis und Spezialdip                                Biersauce, Bayrisch Kraut
+                                                                    Meerrettich und Kartoffeln                            karamellisierten Möhren
+                        Rindfleisch dazu Reis                                                                                                                                                                                                  und Semmelknödel
+                                                        4,80 €                                              6,20 €                                               7,50 €                                                      7,20 €                                       5,90 €
+
+
+                                                                                                        Änderungen vorbehalten - Allergene und Zusatzstoffe siehe Tagesaushänge
+                                                                                           Wir sind immer offen für Anregungen, Kritik und Fragen. Senden Sie uns einfach eine E-Mail an wimmer@konradhof.de
+                                              Wir möchten darauf hinweisen, daß Bestandteile von Laktose 19, glutenhaltigem Getreide 20, Senf 23, Sellerie 22, Eiern 31, Sesam 24 und Geschmacksverstärker 4 in allen unseren Gerichte enthalten sein können.
+                                                Obwohl wir in unserer Küche auf jegliche Geschmacksverstärker wie z.B. Fondor verzichten, beinhalten leider viele Produkte Glutamat (z.B. Gewürzmischungen, Käse, Panaden, Sojasauce aber auch Tomaten)
+

--- a/src/test/assets/ipp/KW-37_-10.09.-14.09.2018_two_line_soup.txt
+++ b/src/test/assets/ipp/KW-37_-10.09.-14.09.2018_two_line_soup.txt
@@ -1,0 +1,62 @@
+                                                                                                     KONRADHOF CATERING - Betriebskantine IPP
+
+                                               Speiseplan KW                                                            37                                        Montag, 10. September 2018 bis Freitag, 14. September 2018
+
+
+                                    Montag                                           Dienstag                                            Mittwoch                                            Donnerstag                                                      Freitag
+
+
+
+                           T agessuppe siehe                             T agessuppe siehe                                  T agessuppe siehe
+                                                                                                                                                                           T agessuppe siehe Aushang                                  T agessuppe siehe Aushang
+   Suppentopf                  Aushang                                          Aushang                                            Aushang
+                                                                                                                                                                                     Preis ab 0,90 €                                           Preis ab 0,90 €
+                            Preis ab 0,90 €                                Preis ab 0,90 €                                    Preis ab 0,90 €
+
+                            Pasta mit Sauce
+                               Ratatouille                                Wirsingeintopf mit                             Rotes Panang Curry mit
+                                                                                                                                                                              Gemüsemaultaschen mit                                   Reisauflauf mit Gemüse und
+      Veggie                                                       Kartoffeln und Karotten (mit                        Gemüse, Kokosmilch und
+                                                                                                                                                                                  Schnittlauchsauce                                            Schnittlauchdip
+                                                                           Bockwurst 4,20€)                                      Basmatireis
+
+                                                         3,50 €                                             3,50 €                                            4,90 €                                                    3,50 €                                           3,50 €
+
+
+
+
+                             Putensteak mit                            Zwiebelrostbraten, mit                                     Gebratene                                 Überbackenes Schnitzel mit
+                                                                                                                                                                                                                                       Seelachsfilet auf rahmigen
+Traditionelle Küche     Kräuterbutter, saisonalem                         Champigonrahm,                                 Mohnschupfnudeln mit                              Mais und Paprika dazu Salsa
+                                                                                                                                                                                                                                        Gemüse mit Salzkartoffeln
+                       Gemüse und Pommes frites                     Röstzwiebeln und Spätzle                                       Kompott                                         und Ofenkartoffeln
+                                                         6,20 €                                             7,90 €                                            3,50 €                                                    5,90 €                                         5,80 €
+
+
+                                                                                                                                                                                Minifrühlingsrollen auf
+                          Geschnetzeltes vom                                    Börek mit                                                                                 Wokgemüse mit Reis und süß-
+                                                                                                                       Gnocci in Salbeibutter mit                                                                                     Pasta in Weißweinsahne mit
+Internationale Küche   Schwein mit Champignons                           Schafskäsefüllung                                                                                          saurem Chilidip
+                                                                                                                               Grana Padano                                                                                             Pilzen und Grana Padano
+                            und Gemüsereis                             Rohkostsalat und Dip
+                                                         5,20 €                                             5,20 €                                            4,90 €                                                    4,90 €                                         4,50 €
+
+
+
+                                                                                                                                 Gebackenes
+                                                                        Strozzapreti in Lauch-
+                       "Alu Gobi" Blumenkohl und                                                                            Putenschnitzel mit                                                                                     T eriyaki-Rindfleisch mit buntem
+                                                                    Sahnesauce mit T omate,                                                                                       Würst´l Gulasch mit
+     Specials             Kartoffeln in pikanter                                                                           Pommes frites oder                                                                                       Gemüse, Ingwer, Sprossen und
+                                                                       geriebenem Käse und                                                                                          Baguettesemmel
+                             Joghurtsauce                                                                                    Kartoffelsalat und                                                                                                        Reis
+                                                                                Croutons
+                                                                                                                               Preiselbeeren
+                                                         4,90 €                                             4,60 €                                            6,50 €                                                    4,20 €                                         7,50 €
+
+
+                                                                                                          Änderungen vorbehalten - Allergene und Zusatzstoffe siehe Tagesaushänge
+                                                                                            Wir sind immer offen für Anregungen, Kritik und Fragen. Senden Sie uns einfach eine E-Mail an wimmer@konradhof.de
+                                              Wir möchten darauf hinweisen, daß Bestandteile von Laktose 19, glutenhaltigem Getreide 20, Senf 23, Sellerie 22, Eiern 31, Sesam 24 und Geschmacksverstärker 4 in allen unseren Gerichte enthalten sein können.
+                                                   Obwohl wir in unserer Küche auf jegliche Geschmacksverstärker wie z.B. Fondor verzichten, beinhalten leider viele Produkte Glutamat (z.B. Gewürzmischungen, Käse, Panaden, Sojasauce aber auch Tomaten)
+


### PR DESCRIPTION
Since last week the "Tagessuppe siehe Aushang" string is splitted into two lines for Monday til Wednesday:
![auswahl_026](https://user-images.githubusercontent.com/4788201/45098658-b7c75380-b125-11e8-984a-9e21151d0c17.png)

I hoped this was only last week, but they continued doing this.
This PR will check for the two line string and adapt the column detection so that the menus will correctly parsed again. The code is still compatible with one line "Tagessuppe siehe Aushang", including if they fully revert to the old behavior (all days with one line). I did not do extensive testing, but it seems to work quite well. But I still hope the two lines will not be permanent.