### PR TITLE
Fixed variable referenced before assignment

### DIFF
--- a/src/menu_parser.py
+++ b/src/menu_parser.py
@@ -236,6 +236,7 @@ class FMIBistroMenuParser(MenuParser):
 
         # currently, up to 5 dishes are on the menu
         num_dishes = 5
+        line_aktion = []
         if year < 2018:
             # in older versions of the FMI Bistro menu, the Aktionsgericht was the same for the whole week
             num_dishes = 3


### PR DESCRIPTION
Fixed parser for fmi-bistro:
```
Traceback (most recent call last):
  File "main.py", line 122, in <module>
    main()
  File "main.py", line 81, in main
    menus = parser.parse(location)
  File "/home/fabian/Documents/eat-api/my/menu_parser.py", line 202, in parse
    parsed_menus = self.get_menus(data, year, week_number)
  File "/home/fabian/Documents/eat-api/my/menu_parser.py", line 243, in get_menus
    if len(line_aktion) == 1:
UnboundLocalError: local variable 'line_aktion' referenced before assignment

```