### PR TITLE
Ingredients split capital letters

### DIFF
--- a/src/entities.py
+++ b/src/entities.py
@@ -102,8 +102,9 @@ class Week:
 
         return weeks
 
+
 class Ingredients:
-    # A dictionary of all ingredients (from the Studentenwerk) with their description:
+
     ingredient_lookup = {
         "GQB" : "Certified Quality - Bavaria",
         "MSC" : "Marine Stewardship Council",
@@ -128,9 +129,9 @@ class Ingredients:
         "S" : "with pork",
         "R" : "with beef",
         "K" : "with veal",
-        "G" : "with poultry", # mediziner mensa
-        "W" : "with wild meat", # mediziner mensa
-        "L" : "with lamb", # mediziner mensa
+        "G" : "with poultry",  # mediziner mensa
+        "W" : "with wild meat",  # mediziner mensa
+        "L" : "with lamb",  # mediziner mensa
         "Kn" : "with garlic",
         "Ei" : "with chicken egg",
         "En" : "with peanut",
@@ -157,6 +158,7 @@ class Ingredients:
         "Sw" : "with sulfur dioxide and sulfites",
         "Wt" : "with mollusks",
     }
+    """A dictionary of all ingredients (from the Studentenwerk) with their description."""
 
     fmi_ingredient_lookup = {
         "Gluten" : "Gl",


### PR DESCRIPTION
In the last weeks since we have the ingredients implementation, I got log warning messages like this:

```
Unknown ingredient for fmi-bistro found: SenfGluten
Unknown ingredient for fmi-bistro found: EiSoja
```

It seems to, that  regularily the `,` missing between the ingredients and hence the parser fails for this unseparated ingredients.
I extended the code that when the splitting with `,` fails, the parser tries to split the failed elements with capital letters again. With that we are able to als cope the above problems.